### PR TITLE
Fix for Start Date and End Date not displayed in a Windows environment

### DIFF
--- a/artefact/cpds/lib.php
+++ b/artefact/cpds/lib.php
@@ -611,9 +611,13 @@ class ArtefactTypeActivity extends ArtefactType {
             foreach ($results as $result) {
                 $grandtotalhours = $grandtotalhours + $result->hours;
                 if (!empty($result->startdate)) {
-                    $result->startdate = strftime(get_string('strftimedate'), $result->startdate);
+                    $format = get_string('strftimedate');
+                    if (strtoupper(substr(PHP_OS, 0, 3)) == 'WIN') {
+                        $format = preg_replace('#(?<!%)((?:%%)*)%e#', '\1%#d', $format);
+                    }
+                    $result->startdate = strftime($format, $result->startdate);
                     if (!empty($result->enddate)) {
-                        $result->enddate = strftime(get_string('strftimedate'), $result->enddate);
+                        $result->enddate = strftime($format, $result->enddate);
                     }
                 }
             }


### PR DESCRIPTION
In a Windows environment strftime(get_string('strftimedate') returns false. 

According to http://php.net/manual/en/function.strftime.php this is because "the %e modifier is not supported in the Windows implementation of this function".

This has the effect of setting $result->startdate and $result->enddate to false which means the Start Date and End Date are not displayed in a Windows-based environment.

Fixed as per http://stackoverflow.com/questions/12230112/php-strftime-returns-false

